### PR TITLE
Support 'npm start' under linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prepublish": "grunt",
     "build": "grunt",
-    "start": "open index.html"
+    "start": "open index.html || sensible-browser index.html || xdg-open index.html"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
using either sensible-browser (debian-like systems) or xdg-open (systems that
have xdg-utils installed).
