### PR TITLE
Fixed "toggle all" to send PATCH instead of PUT

### DIFF
--- a/js/views/app-view.js
+++ b/js/views/app-view.js
@@ -122,9 +122,7 @@ var app = app || {};
 			var completed = this.allCheckbox.checked;
 
 			app.todos.each(function (todo) {
-				todo.save({
-					completed: completed
-				});
+				todo.toggle();
 			});
 		}
 	});


### PR DESCRIPTION
The todo-backend-api spec only defines PATCH and not PUT, so this
functionality was broken for most of the APIs.